### PR TITLE
Fix comment for duplicate ID check

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -60,7 +60,7 @@ def create_picture():
     picture_in = request.json
     print(picture_in)
 
-    # if the id is already there, return 303 with the URL for the resource
+    # if the id is already there, return HTTP 302 with the URL for the resource
     for picture in data:
         if picture_in["id"] == picture["id"]:
             return {


### PR DESCRIPTION
## Summary
- clarify that duplicate ID logic returns HTTP 302

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684543ab88088323957bb6ec050302b9